### PR TITLE
Fix jittery stat counters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "react-dom": "^18.3.1",
         "react-markdown": "^9.0.1",
         "react-player": "^2.16.0",
-        "react-slot-counter": "^2.3.3",
+        "react-slot-counter": "^3.0.1",
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
@@ -14385,9 +14385,10 @@
       }
     },
     "node_modules/react-slot-counter": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/react-slot-counter/-/react-slot-counter-2.3.3.tgz",
-      "integrity": "sha512-8mkJ2v1iUUEwsL8WTPkt9CiMm9pYw4Nu96jt367/uqyMjYMl/rwDE6eJLDiUKcRXq6yVuF1LuKym9TKt8FpzxA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-slot-counter/-/react-slot-counter-3.0.1.tgz",
+      "integrity": "sha512-+NwzRrZ+zWErP/8nz+0Y/imtOcMDr1A2Gv8CfzXNRW/zXaxNPMpZQdWeJAX/HiSqaeGc+jxKqKscoMN101NYDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1",
     "react-player": "^2.16.0",
-    "react-slot-counter": "^2.3.3",
+    "react-slot-counter": "^3.0.1",
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The counters were constantly re-rendering, but this new version of react-slot-counter seems to fix it.